### PR TITLE
Add Network category with Sonarnet library

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Please read the [contribution guidelines](CONTRIBUTING.md) if you want to contri
 
 
 
+### <a name="network"></a>Network <sup>[Back ⇈](#contents)</sup>
+* [Sonarnet](https://github.com/fabricethilaw/sonarnet) - Kotlin library providing better awareness of true Internet access and captive portals for Android.
+
+
+
 ## <a name="projects"></a>Projects <sup>[Back ⇈](#contents)</sup>
 * [Bandhook Kotlin](https://github.com/antoniolg/Bandhook-Kotlin) - A showcase music app for Android entirely written using Kotlin language.
 * [Kotlin for Android Developers](https://github.com/antoniolg/Kotlin-for-Android-Developers) - Companion App for the book "Kotlin Android Developers".


### PR DESCRIPTION
ConnectivityManager is a well known class in the Android framework API that allows for detecting network data.
But this class does not generally return accurate results in situations where for example a device is connected to a Wi-Fi router that has no Internet access.

Sonarnet wraps the ConnectivityManager and mimics the Android OS mean of detecting Internet access on connected networks. This library also helps skip the boilerplate code with a simple interface.

The way Sonarnet detects internet connectivity is aslo similar to the one used by Google Chrome App, as described here : https://www.google.com/chrome/privacy/whitepaper.html#offline